### PR TITLE
Remove webview from automatic monitoring

### DIFF
--- a/Sources/InstanaAgent/Monitors/HTTP/InstanaURLProtocol.swift
+++ b/Sources/InstanaAgent/Monitors/HTTP/InstanaURLProtocol.swift
@@ -140,23 +140,12 @@ extension InstanaURLProtocol {
     // We do some swi**ling to inject our InstanaURLProtocol to all custom sessions automatically
     // Will be called only once by using a static let
     static let install: () = {
-        prepareWebView
         prepareURLSessions
     }()
 
     static func deinstall() {
         URLSessionConfiguration.removeAllInstanaURLProtocol()
     }
-
-    // Will be called only once by using a static let
-    static let prepareWebView: () = {
-        guard let something = WKWebView().value(forKey: "browsingContextController") as? NSObject else { return }
-        let selector = NSSelectorFromString("registerSchemeForCustomProtocol:")
-        if type(of: something).responds(to: selector) {
-            type(of: something).perform(selector, with: "http")
-            type(of: something).perform(selector, with: "https")
-        }
-    }()
 
     // Will be called only once by using a static let
     static let prepareURLSessions: () = {

--- a/Tests/InstanaAgentTests/IntegrationTest/InstanaURLProtocolIntegrationTests.swift
+++ b/Tests/InstanaAgentTests/IntegrationTest/InstanaURLProtocolIntegrationTests.swift
@@ -86,29 +86,6 @@ class InstanaURLProtocolIntegrationTests: InstanaTestCase {
         AssertEqualAndNotNil(resultBeacon?.url, givenURL)
     }
 
-    func test_urlprotocol_with_Webview_mock_report() {
-        // Given
-        let didReportWait = expectation(description: "didFinish")
-        var resultBeacon: HTTPBeacon?
-        let mockReporter = MockReporter { submittedBeacon in
-            if let httpBeacon = submittedBeacon as? HTTPBeacon {
-                resultBeacon = httpBeacon
-                didReportWait.fulfill()
-            }
-        }
-        let monitors = Monitors(session, reporter: mockReporter)
-        Instana.current = Instana(configuration: session.configuration, monitors: monitors)
-        let webView = WKWebView()
-
-        // When
-        webView.load(URLRequest(url: givenURL))
-        wait(for: [didReportWait], timeout: 10)
-
-        // Then
-        AssertEqualAndNotNil(resultBeacon?.url, givenURL)
-    }
-
-
     // MARK: Helper
     class SecondURLProtocol: URLProtocol {
         static var monitoredURL: URL?

--- a/tools/Webserver/Webserver.swift
+++ b/tools/Webserver/Webserver.swift
@@ -35,7 +35,10 @@ public class Webserver {
 
     init(port: UInt16) {
         let tcpprotocol = NWProtocolTCP.Options()
+     //   tcpprotocol.enableKeepalive = true
         tcpprotocol.connectionTimeout = 60
+     //   tcpprotocol.keepaliveIdle = 5
+      //  tcpprotocol.enableFastOpen = true
         listener = try! NWListener(using: NWParameters(tls: nil, tcp: tcpprotocol), on: NWEndpoint.Port(rawValue: port)!)
     }
 
@@ -95,7 +98,6 @@ public class Webserver {
     func verifyBeaconReceived(key: String, value: String, file: StaticString = #file, line: UInt = #line) -> Bool {
         let keyValuePair = "\(key)\t\(value)"
         let hasValue = connections.flatMap {$0.received}.first(where: { $0.contains(keyValuePair) }) != nil
-        let all = connections.flatMap {$0.received}
         if !hasValue {
             XCTFail("Could not find value: \(value) for key: \(key))", file: file, line: line)
         }


### PR DESCRIPTION
Automatic monitoring of the `WKWebView` `URLSession` is not reliable since the `WKWebView` and `WebKit` run in different processes.
There is an IPC between the app and `WebKit` process but some data (i.e. POST body) are not transmitted to the app process.
This would lead to an unexpected behaviour. POST data would be discarded for instance.