### PR TITLE
Use Set for ReporterQueue

### DIFF
--- a/Sources/InstanaAgent/Beacons/Beacons Types/Beacon.swift
+++ b/Sources/InstanaAgent/Beacons/Beacons Types/Beacon.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Base class for Beacon.
-class Beacon: Identifiable {
+class Beacon {
     let id = UUID()
     var timestamp: Instana.Types.Milliseconds = Date().millisecondsSince1970
     let viewName: String?

--- a/Sources/InstanaAgent/Beacons/CoreBeacon/CoreBeacon.swift
+++ b/Sources/InstanaAgent/Beacons/CoreBeacon/CoreBeacon.swift
@@ -16,7 +16,7 @@ enum BeaconType: String, Equatable, Codable, CustomStringConvertible {
 /// This model uses a short field name to reduce the transfer size
 /// We transfer a simple String (no json) to the backend via the HTTP body.
 /// That means we also loose the type information, so we need treat all fields as String
-struct CoreBeacon: Equatable, Codable {
+struct CoreBeacon: Codable {
     /**
      * The max byte for each field (bytes)
      *
@@ -327,4 +327,16 @@ struct CoreBeacon: Equatable, Codable {
      * For example: "Timeout"
      */
     var et: String?
+}
+
+extension CoreBeacon: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(bid)
+    }
+}
+
+extension CoreBeacon: Equatable {
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        return lhs.bid == rhs.bid
+    }
 }

--- a/Sources/InstanaAgent/Beacons/Reporter.swift
+++ b/Sources/InstanaAgent/Beacons/Reporter.swift
@@ -115,7 +115,7 @@ public class Reporter {
             return complete([], .failure(InstanaError(code: .lowBattery, description: "Battery too low for flushing")))
         }
 
-        let beacons = queue.items
+        let beacons = Array(queue.items)
         let beaconsAsString = beacons.asString
         let request: URLRequest
         do {

--- a/Sources/InstanaAgent/Configuration/InstanaProperties.swift
+++ b/Sources/InstanaAgent/Configuration/InstanaProperties.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct InstanaProperties: Equatable {
-    struct User: Identifiable, Equatable {
+    struct User: Equatable {
         /// Unique identifier for the user
         var id: String
         /// User's email address

--- a/Tests/InstanaAgentTests/Beacons/ReporterTests.swift
+++ b/Tests/InstanaAgentTests/Beacons/ReporterTests.swift
@@ -155,7 +155,7 @@ class ReporterTests: InstanaTestCase {
         // Then
         AssertTrue(reporter.queue.items.count == 1)
         AssertTrue(sendCount == 0)
-        AssertEqualAndNotNil(reporter.queue.items.last?.bid, givenBeacon.id.uuidString)
+        AssertEqualAndNotNil(reporter.queue.items.randomElement()?.bid, givenBeacon.id.uuidString)
 
         // Wait for final flush
         wait(for: [finalExp], timeout: 5.0)
@@ -858,7 +858,7 @@ class ReporterTests: InstanaTestCase {
         AssertTrue(sendCount == 2)
         AssertTrue(sendQueue.addedItems.count == 2)
         AssertEqualAndNotNil(sendQueue.addedItems.first?.bid, beacon1.id.uuidString)
-        AssertEqualAndNotNil(sendQueue.addedItems.last?.bid, beacon2.id.uuidString)
+        AssertEqualAndNotNil(sendQueue.addedItems.randomElement()?.bid, beacon2.id.uuidString)
     }
 
 
@@ -887,7 +887,7 @@ class ReporterTests: InstanaTestCase {
 
         // Then
         AssertEqualAndNotNil(resultError, givenError)
-        AssertEqualAndNotNil(reporter.queue.items.last?.bid, givenBeacon.id.uuidString)
+        AssertEqualAndNotNil(reporter.queue.items.randomElement()?.bid, givenBeacon.id.uuidString)
     }
 
     func test_invalid_beacon_should_not_submitted() {

--- a/Tests/InstanaAgentTests/Mocks/MockInstanaPersistableQueue.swift
+++ b/Tests/InstanaAgentTests/Mocks/MockInstanaPersistableQueue.swift
@@ -2,17 +2,17 @@ import Foundation
 import XCTest
 @testable import InstanaAgent
 
-class MockInstanaPersistableQueue<T: Codable & Equatable>: InstanaPersistableQueue<T> {
+class MockInstanaPersistableQueue<T: Codable & Hashable>: InstanaPersistableQueue<T> {
 
-    var addedItems = [T]()
+    var addedItems = Set<T>()
 
     override func add(_ item: T, _ completion: Completion? = nil) {
         super.add([item], completion)
-        addedItems.append(item)
+        addedItems.insert(item)
     }
 
     override func add(_ newItems: [T], _ completion: Completion? = nil) {
         super.add(newItems, completion)
-        addedItems.append(contentsOf: newItems)
+        addedItems.formUnion(newItems)
     }
 }


### PR DESCRIPTION
- Avoid CoreBeacon dups
- CoreBeacons are hashed with the beacon identifier
- Adds new tests