### PR TITLE
We can't use nil for primitive values in ObjC

### DIFF
--- a/Sources/InstanaAgent/Instana.swift
+++ b/Sources/InstanaAgent/Instana.swift
@@ -231,9 +231,10 @@ import UIKit
     ///                            If you send explicitly nil, the viewName will be ignored.
     ///                            Alternatively you can leave out the parameter `viewName` to use the current view name you did set in `setView(name: String)`)
     @objc
-    public static func reportEvent(name: String, timestamp: String? = nil, duration: String? = nil, backendTracingID: String? = nil, error: Error? = nil, meta: [String: String]? = nil, viewName: String? = CustomBeaconDefaultViewNameID) {
-        let timestamp = Instana.Types.Milliseconds(timestamp ?? "")
-        let duration = Instana.Types.Milliseconds(duration ?? "")
+    public static func reportEvent(name: String, timestamp: Instana.Types.Milliseconds = Instana.Types.Milliseconds(NSNotFound), duration: Instana.Types.Milliseconds = Instana.Types.Milliseconds(NSNotFound), backendTracingID: String? = nil, error: Error? = nil, meta: [String: String]? = nil, viewName: String? = CustomBeaconDefaultViewNameID) {
+        // As a workaround for primitive values in ObjC
+        let timestamp = timestamp == NSNotFound ? nil : timestamp
+        let duration = duration == NSNotFound ? nil : duration
         let beacon = CustomBeacon(timestamp: timestamp,
                                   name: name,
                                   duration: duration,

--- a/Tests/InstanaAgentTests/InstanaTests.swift
+++ b/Tests/InstanaAgentTests/InstanaTests.swift
@@ -262,8 +262,8 @@ class InstanaTests: InstanaTestCase {
     func test_reportCustom_AllValues() {
         // Given
         let name = "Custom Event"
-        let duration = "1"
-        let timestamp = "123"
+        let duration: Instana.Types.Milliseconds = 1
+        let timestamp: Instana.Types.Milliseconds = 123
         let backendID = "B123"
         let error = NSError(domain: "Domain", code: 100, userInfo: nil)
         let meta = ["Key": "Value"]

--- a/Tests/InstanaAgentTests/IntegrationTest/InstanaIntegrationTests.swift
+++ b/Tests/InstanaAgentTests/IntegrationTest/InstanaIntegrationTests.swift
@@ -144,9 +144,9 @@ class InstanaIntegrationTests: InstanaTestCase {
     func test_Instana_report_custom_event() {
         // Given
         let waitFor = expectation(description: "Wait For")
-        let timestamp = "1234"
+        let timestamp: Instana.Types.Milliseconds = 1234
         let name = "Some name"
-        let duration = "12"
+        let duration: Instana.Types.Milliseconds = 12
         let backendTracingID = "BackendID"
         let error: NSError = InstanaError(code: .invalidResponse, description: "Some")
         let mKey = "Key"
@@ -164,8 +164,8 @@ class InstanaIntegrationTests: InstanaTestCase {
         wait(for: [waitFor], timeout: 5.0)
         AssertEqualAndNotNil(sentBeacon?.v, viewName) // Overrides the default set in session.propertyHandler.properties
         AssertEqualAndNotNil(sentBeacon?.bt, backendTracingID)
-        AssertEqualAndNotNil(sentBeacon?.ti, timestamp)
-        AssertEqualAndNotNil(sentBeacon?.d, duration)
+        AssertEqualAndNotNil(sentBeacon?.ti, "\(timestamp)")
+        AssertEqualAndNotNil(sentBeacon?.d, "\(duration)")
         AssertEqualAndNotNil(sentBeacon?.cen, name)
         AssertEqualAndNotNil(sentBeacon?.ec, "\(1)")
         AssertEqualAndNotNil(sentBeacon?.et, "InstanaError")


### PR DESCRIPTION
So we use NSNotFound instead of nil as default value