### PR TITLE
Do not drop values longer than max allowed length.

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/InstanaAgentIntegrationTests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/InstanaAgentIntegrationTests.xcscheme
@@ -33,6 +33,9 @@
                   Identifier = "BasicIntegrationServerTest">
                </Test>
                <Test
+                  Identifier = "BeaconTests">
+               </Test>
+               <Test
                   Identifier = "CoreBeaconExtensionsTests">
                </Test>
                <Test
@@ -43,6 +46,9 @@
                </Test>
                <Test
                   Identifier = "CustomBeaconTests">
+               </Test>
+               <Test
+                  Identifier = "DefaultIgnoredURLsTests">
                </Test>
                <Test
                   Identifier = "FramerateDropMonitorTests">

--- a/Sources/InstanaAgent/Beacons/Beacons Types/Beacon.swift
+++ b/Sources/InstanaAgent/Beacons/Beacons Types/Beacon.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// Base class for Beacon.
 class Beacon {
+
     let id = UUID()
     var timestamp: Instana.Types.Milliseconds = Date().millisecondsSince1970
     let viewName: String?
@@ -9,7 +10,7 @@ class Beacon {
     init(timestamp: Instana.Types.Milliseconds = Date().millisecondsSince1970,
          viewName: String? = nil) {
         self.timestamp = timestamp
-        self.viewName = viewName
+        self.viewName = InstanaProperties.validate(view: viewName)
     }
 }
 

--- a/Sources/InstanaAgent/Beacons/Beacons Types/CustomBeacon.swift
+++ b/Sources/InstanaAgent/Beacons/Beacons Types/CustomBeacon.swift
@@ -17,19 +17,19 @@ class CustomBeacon: Beacon {
     let duration: Instana.Types.Milliseconds?
     let backendTracingID: String?
     let error: Error?
-    let meta: [String: String]?
+    let metaData: MetaData?
 
     init(timestamp: Instana.Types.Milliseconds? = nil,
          name: String,
          duration: Instana.Types.Milliseconds? = nil,
          backendTracingID: String? = nil,
          error: Error? = nil,
-         meta: [String: String]? = nil,
+         metaData: MetaData? = nil,
          viewName: String? = CustomBeaconDefaultViewNameID) {
         self.duration = duration
         self.name = name
         self.error = error
-        self.meta = meta
+        self.metaData = metaData
         self.backendTracingID = backendTracingID
         var start = Date().millisecondsSince1970
         if let duration = duration {

--- a/Sources/InstanaAgent/Beacons/Beacons Types/HTTPBeacon.swift
+++ b/Sources/InstanaAgent/Beacons/Beacons Types/HTTPBeacon.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 class HTTPBeacon: Beacon {
+    static let maxLengthURL: Int = 4096
+
     let duration: Instana.Types.Milliseconds
     let method: String
     let url: URL
@@ -22,7 +24,8 @@ class HTTPBeacon: Beacon {
         let path = !url.path.isEmpty ? url.path : nil
         self.duration = duration
         self.method = method
-        self.url = url
+        let urlString = url.absoluteString.cleanEscapeAndTruncate(at: Self.maxLengthURL, trailing: "")
+        self.url = URL(string: urlString) ?? url
         self.path = path
         self.responseCode = responseCode
         self.responseSize = responseSize

--- a/Sources/InstanaAgent/Beacons/CoreBeacon/CoreBeacon+Extensions.swift
+++ b/Sources/InstanaAgent/Beacons/CoreBeacon/CoreBeacon+Extensions.swift
@@ -19,31 +19,22 @@ extension CoreBeacon {
 
     func formattedKVPair(key: String, value: Any) -> String? {
         guard Mirror.isNotNil(value: value) else { return nil }
-        if let dict = value as? [AnyHashable: AnyObject] {
+        if let dict = value as? MetaData {
             return dict.asString(prefix: key)
         }
-        let value = "\(value)".cleanAndEscape()
+        let value = "\(value)".coreBeaconClean()
+        guard !value.isEmpty else { return nil }
         return "\(key)\t\(value)"
     }
 }
 
-extension Dictionary {
-    func asString(prefix: String) -> String {
-        return map {
-            let value = "\($0.value)".cleanAndEscape()
-            return "\(prefix)_\($0.key)\t\(value)"
+extension MetaData {
+    func asString(prefix: String) -> String? {
+        guard count > 0 else { return nil }
+        return compactMap {
+            guard !$0.value.isEmpty else { return nil }
+            return "\(prefix)_\($0.key)\t\($0.value.coreBeaconClean())"
         }.joined(separator: "\n")
-    }
-}
-
-extension String {
-    func cleanAndEscape() -> Self {
-        var trimmed = trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-        trimmed = trimmed.truncated(at: Int(CoreBeacon.maxBytesPerField))
-        trimmed = trimmed.replacingOccurrences(of: "\\", with: "\\\\")
-        trimmed = trimmed.replacingOccurrences(of: "\n", with: "\\n")
-        trimmed = trimmed.replacingOccurrences(of: "\t", with: "\\t")
-        return trimmed
     }
 }
 

--- a/Sources/InstanaAgent/Beacons/CoreBeacon/CoreBeacon.swift
+++ b/Sources/InstanaAgent/Beacons/CoreBeacon/CoreBeacon.swift
@@ -23,7 +23,7 @@ struct CoreBeacon: Codable {
      *
      * Default: To be discussed if it can be dynamic
      */
-    static let maxBytesPerField: Instana.Types.Bytes = 10000
+    static let maxLengthPerField: Int = 16384
 
     /**
      * The type of the beacon.
@@ -113,7 +113,7 @@ struct CoreBeacon: Codable {
      *
      * optional
      */
-    var m: [String: String]?
+    var m: MetaData?
 
     /**
      * User ID

--- a/Sources/InstanaAgent/Beacons/CoreBeacon/CoreBeaconFactory.swift
+++ b/Sources/InstanaAgent/Beacons/CoreBeacon/CoreBeaconFactory.swift
@@ -43,7 +43,7 @@ extension CoreBeacon {
         ui = properties.user?.id
         un = properties.user?.name
         ue = properties.user?.email
-        m = properties.metaData
+        m = !properties.metaData.isEmpty ? properties.metaData : nil
     }
 
     mutating func append(_ beacon: HTTPBeacon) {
@@ -91,7 +91,7 @@ extension CoreBeacon {
         let useCurrentVisibleViewName = beacon.viewName == CustomBeaconDefaultViewNameID
         v = useCurrentVisibleViewName ? properties.viewNameForCurrentAppState : beacon.viewName
         cen = beacon.name
-        m = beacon.meta
+        m = beacon.metaData
         if let error = beacon.error {
             add(error: error)
         }

--- a/Sources/InstanaAgent/Instana.swift
+++ b/Sources/InstanaAgent/Instana.swift
@@ -157,12 +157,7 @@ import UIKit
     @objc
     public static func setMeta(value: String, key: String) {
         guard let propertyHandler = Instana.current?.session.propertyHandler else { return }
-        guard propertyHandler.validate(value: value) else { return }
-        var metaData = propertyHandler.properties.metaData ?? [:]
-        metaData[key] = value
-        if propertyHandler.validate(keys: Array(metaData.keys)) {
-            propertyHandler.properties.metaData = metaData
-        }
+        propertyHandler.properties.appendMetaData(key, value)
     }
 
     /// User-specific information
@@ -240,7 +235,7 @@ import UIKit
                                   duration: duration,
                                   backendTracingID: backendTracingID,
                                   error: error,
-                                  meta: meta,
+                                  metaData: meta,
                                   viewName: viewName)
         Instana.current?.monitors.reporter.submit(beacon)
     }

--- a/Sources/InstanaAgent/Utils/Extensions/String+Extras.swift
+++ b/Sources/InstanaAgent/Utils/Extensions/String+Extras.swift
@@ -1,11 +1,26 @@
 import Foundation
 
 extension String {
-    func truncated(at length: Int, trailing: String = "…") -> String {
+    func coreBeaconClean() -> String {
+        cleanEscapeAndTruncate(at: CoreBeacon.maxLengthPerField)
+    }
+
+    func cleanEscapeAndTruncate(at length: Int, trailing: String = "…") -> String {
+        return cleanEscape().maxLength(length, trailing: trailing)
+    }
+
+    func cleanEscape() -> String {
+        var trimmed = trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+        trimmed = trimmed.replacingOccurrences(of: "\\", with: "\\\\")
+        trimmed = trimmed.replacingOccurrences(of: "\n", with: "\\n")
+        trimmed = trimmed.replacingOccurrences(of: "\t", with: "\\t")
+        return trimmed
+    }
+
+    func maxLength(_ length: Int, trailing: String = "…") -> String {
         if count <= length {
             return self
         }
-        let truncated = prefix(length)
-        return truncated + trailing
+        return String(prefix(length - trailing.count)) + trailing
     }
 }

--- a/Tests/InstanaAgentTests/Beacons/Beacon Types/BeaconTests.swift
+++ b/Tests/InstanaAgentTests/Beacons/Beacon Types/BeaconTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import InstanaAgent
+
+class BeaconTests: InstanaTestCase {
+
+    func test_Beacon_viewNameMaxBytes() {
+        AssertTrue(InstanaProperties.viewMaxLength == 256)
+    }
+
+    func test_view_name_valid_length() {
+        // Given
+        let given = (0..<InstanaProperties.viewMaxLength).map {_ in "A"}.joined()
+
+        // When
+        let sut = Beacon(timestamp: 0, viewName: given)
+
+        // Then
+        AssertEqualAndNotNil(sut.viewName, given)
+    }
+
+    func test_view_name_valid_exceeds_max_length() {
+        // Given
+        let given = (0...InstanaProperties.viewMaxLength).map {_ in "A"}.joined()
+
+        // When
+        let sut = Beacon(timestamp: 0, viewName: given)
+
+        // Then
+        AssertEqualAndNotNil(sut.viewName, given.cleanEscapeAndTruncate(at: InstanaProperties.viewMaxLength))
+    }
+}

--- a/Tests/InstanaAgentTests/Beacons/Beacon Types/CustomBeaconTests.swift
+++ b/Tests/InstanaAgentTests/Beacons/Beacon Types/CustomBeaconTests.swift
@@ -12,11 +12,10 @@ class CustomBeaconTests: InstanaTestCase {
 
         // Then
         AssertEqualAndNotNil(sut.name, name)
-        AssertEqualAndNotNil(sut.timestamp, Date().millisecondsSince1970)
         XCTAssertNil(sut.backendTracingID)
         AssertEqualAndNotNil(sut.viewName, CustomBeaconDefaultViewNameID)
         XCTAssertNil(sut.duration)
-        XCTAssertNil(sut.meta)
+        XCTAssertNil(sut.metaData)
         XCTAssertNil(sut.error)
     }
 
@@ -34,7 +33,7 @@ class CustomBeaconTests: InstanaTestCase {
         XCTAssertNil(sut.backendTracingID)
         AssertEqualAndNotNil(sut.viewName, viewName)
         XCTAssertNil(sut.duration)
-        XCTAssertNil(sut.meta)
+        XCTAssertNil(sut.metaData)
         XCTAssertNil(sut.error)
     }
 
@@ -99,7 +98,7 @@ class CustomBeaconTests: InstanaTestCase {
         XCTAssertNotNil(customBeacon.viewName)
         XCTAssertNotNil(customBeacon.duration)
         XCTAssertTrue(customBeacon.timestamp > 0)
-        XCTAssertNotNil(customBeacon.meta)
+        XCTAssertNotNil(customBeacon.metaData)
         XCTAssertNotNil(customBeacon.error)
         XCTAssertNotNil(customBeacon.backendTracingID)
 
@@ -107,7 +106,7 @@ class CustomBeaconTests: InstanaTestCase {
         AssertEqualAndNotNil(beacon.cen, customBeacon.name)
         AssertEqualAndNotNil(beacon.d, "\(customBeacon.duration ?? 0)")
         AssertEqualAndNotNil(beacon.ti, "\(customBeacon.timestamp)")
-        AssertEqualAndNotNil(beacon.m, customBeacon.meta)
+        AssertEqualAndNotNil(beacon.m, customBeacon.metaData)
         AssertEqualAndNotNil(beacon.bt, customBeacon.backendTracingID)
         AssertEqualAndNotNil(beacon.et, "\(type(of: customBeacon.error!))")
         AssertEqualAndNotNil(beacon.em, "\(customBeacon.error!)")
@@ -116,7 +115,7 @@ class CustomBeaconTests: InstanaTestCase {
         let expectediOSVersion = UIDevice.current.systemVersion
         let expectedErrorType = "\(type(of: customBeacon.error!))"
         let expectedErrorMessage = "\(customBeacon.error!)"
-        let expected = "ab\t\(beacon.ab)\nagv\t\(beacon.agv)\nav\tunknown-version\nbi\t\(beacon.bi)\nbid\t\(beacon.bid)\nbt\t\(customBeacon.backendTracingID ?? "")\ncen\t\(customBeacon.name)\ncn\tNone\nct\t\(InstanaSystemUtils.networkUtility.connectionType.description)\nd\t\(customBeacon.duration ?? 0)\ndma\tApple\ndmo\tx86_64\nec\t1\nem\t\(expectedErrorMessage)\net\t\(expectedErrorType)\nk\tKEY\nm_\(customBeacon.meta?.keys.first ?? "")\t\(customBeacon.meta?.values.first ?? "")\nosn\tiOS\nosv\t\(expectediOSVersion)\np\tiOS\nro\tfalse\nsid\t\(beacon.sid)\nt\tcustom\nti\t\(customBeacon.timestamp)\nul\ten\nv\t\(customBeacon.viewName ?? "")\nvh\t\(Int(UIScreen.main.nativeBounds.height))\nvw\t\(Int(UIScreen.main.nativeBounds.width))"
+        let expected = "ab\t\(beacon.ab)\nagv\t\(beacon.agv)\nav\tunknown-version\nbi\t\(beacon.bi)\nbid\t\(beacon.bid)\nbt\t\(customBeacon.backendTracingID ?? "")\ncen\t\(customBeacon.name)\ncn\tNone\nct\t\(InstanaSystemUtils.networkUtility.connectionType.description)\nd\t\(customBeacon.duration ?? 0)\ndma\tApple\ndmo\tx86_64\nec\t1\nem\t\(expectedErrorMessage)\net\t\(expectedErrorType)\nk\tKEY\nm_\(customBeacon.metaData?.keys.first ?? "")\t\(customBeacon.metaData?.values.first ?? "")\nosn\tiOS\nosv\t\(expectediOSVersion)\np\tiOS\nro\tfalse\nsid\t\(beacon.sid)\nt\tcustom\nti\t\(customBeacon.timestamp)\nul\ten\nv\t\(customBeacon.viewName ?? "")\nvh\t\(Int(UIScreen.main.nativeBounds.height))\nvw\t\(Int(UIScreen.main.nativeBounds.width))"
         AssertEqualAndNotNil(sut, expected)
     }
 
@@ -214,7 +213,7 @@ class CustomBeaconTests: InstanaTestCase {
         let name = "SomeName"
         let backendTracingID = "BID"
         let error = SomeBeaconError.something
-        let meta = ["Key":"SomeValue"]
-        return CustomBeacon(timestamp: timestamp, name: name, duration: duration, backendTracingID: backendTracingID, error: error, meta: meta, viewName: viewName)
+        let metaData = ["Key": "SomeValue"]
+        return CustomBeacon(timestamp: timestamp, name: name, duration: duration, backendTracingID: backendTracingID, error: error, metaData: metaData, viewName: viewName)
     }
 }

--- a/Tests/InstanaAgentTests/Beacons/Beacon Types/HTTPBeaconTests.swift
+++ b/Tests/InstanaAgentTests/Beacons/Beacon Types/HTTPBeaconTests.swift
@@ -12,12 +12,12 @@ class HTTPBeaconTests: InstanaTestCase {
         let backendTracingID = "BackendTID"
         let timestamp = Date().millisecondsSince1970
         let http = HTTPBeacon(timestamp: timestamp,
-                                method: method,
-                                url: url,
-                                responseCode: 200,
-                                responseSize: responseSize,
-                                backendTracingID: backendTracingID,
-                                viewName: "View Details")
+                              method: method,
+                              url: url,
+                              responseCode: 200,
+                              responseSize: responseSize,
+                              backendTracingID: backendTracingID,
+                              viewName: "View Details")
         let factory = CoreBeaconFactory(.mock)
 
         // When
@@ -49,13 +49,13 @@ class HTTPBeaconTests: InstanaTestCase {
     func test_map_http_with_error() {
         // Given
         let http = HTTPBeacon(timestamp: Date().millisecondsSince1970,
-                                method: "POST",
-                                url: URL.random,
-                                responseCode: 0,
-                                responseSize: HTTPMarker.Size(header: 4, body: 5, bodyAfterDecoding: 6),
-                                error: timeout,
-                                backendTracingID: "BackendTID",
-                                viewName: "View")
+                              method: "POST",
+                              url: URL.random,
+                              responseCode: 0,
+                              responseSize: HTTPMarker.Size(header: 4, body: 5, bodyAfterDecoding: 6),
+                              error: timeout,
+                              backendTracingID: "BackendTID",
+                              viewName: "View")
         let factory = CoreBeaconFactory(.mock)
 
         // When
@@ -77,10 +77,10 @@ class HTTPBeaconTests: InstanaTestCase {
         // Given
         let responseCode = 399
         let http = HTTPBeacon(timestamp: Date().millisecondsSince1970,
-                                method: "POST",
-                                url: URL.random,
-                                responseCode: responseCode,
-                                responseSize: HTTPMarker.Size.random)
+                              method: "POST",
+                              url: URL.random,
+                              responseCode: responseCode,
+                              responseSize: HTTPMarker.Size.random)
         let factory = CoreBeaconFactory(.mock)
 
         // When
@@ -159,7 +159,7 @@ class HTTPBeaconTests: InstanaTestCase {
         // When
         var beacon: CoreBeacon!
         do {
-             beacon = try CoreBeaconFactory(.mock(configuration: .mock)).map(http)
+            beacon = try CoreBeaconFactory(.mock(configuration: .mock)).map(http)
         } catch {
             XCTFail("Could not create CoreBeacon")
         }
@@ -174,6 +174,38 @@ class HTTPBeaconTests: InstanaTestCase {
             let value = child.value as AnyObject
             AssertEqualAndNotNil(sut[child.label] as? String, value.description, "Values for \(child.0) must be same")
         }
+    }
+
+    func test_length_url_valid() {
+        // Given
+        let base = "https://www.google.com/"
+        let suffix = ".html"
+        let path = (0..<HTTPBeacon.maxLengthURL - base.count - suffix.count).map {_ in "A"}.joined()
+        let url = URL(string: base + path + suffix)
+
+        // When
+        let beacon = HTTPBeacon(method: "GET", url: url!, responseCode: 200)
+
+        // Then
+        AssertTrue(beacon.url.absoluteString.count == HTTPBeacon.maxLengthURL)
+        AssertTrue(beacon.url.path.hasSuffix(suffix))
+    }
+
+    func test_length_url_exceeds() {
+        // Given
+        let suffix = ".html"
+        let overflow = suffix.count
+        let base = "https://www.some.com/"
+        let path = (0..<HTTPBeacon.maxLengthURL - base.count - suffix.count + overflow).map {_ in "A"}.joined()
+        let url = URL(string: base + path + suffix)
+
+        // When
+        let beacon = HTTPBeacon(method: "GET", url: url!, responseCode: 200)
+
+        // Then
+        AssertTrue(beacon.url.absoluteString.count == HTTPBeacon.maxLengthURL)
+        AssertFalse(beacon.url.path.contains(suffix))
+        AssertTrue(beacon.url.path.contains(path))
     }
 
     // MARK: Helper

--- a/Tests/InstanaAgentTests/Beacons/CoreBeacon/CoreBeaconTests.swift
+++ b/Tests/InstanaAgentTests/Beacons/CoreBeacon/CoreBeaconTests.swift
@@ -161,6 +161,18 @@ class CoreBeaconTests: InstanaTestCase {
         XCTAssertNil(sut)
     }
 
+    func test_formattedKVPair_empty_value() {
+        // Given
+        let beacon = coreBeacon!
+        let value = ""
+
+        // When
+        let sut = beacon.formattedKVPair(key: "KEY", value: value)
+
+        // When
+        XCTAssertNil(sut)
+    }
+
     func test_cleaning() {
         // Given
         coreBeacon.bt = """
@@ -176,7 +188,7 @@ class CoreBeaconTests: InstanaTestCase {
         XCTAssertEqual(sut, "bt\tTrace ab")
     }
 
-    func test_format_clean_dict() {
+    func test_format_clean_meta() {
         // Given
         coreBeacon.m = ["Key": "Some\nNewline\tTab\\escape", "More": "\ntest\n"]
 
@@ -186,14 +198,24 @@ class CoreBeaconTests: InstanaTestCase {
         // Then
         let valid1 = "m_Key\tSome\\nNewline\\tTab\\\\escape\nm_More\ttest"
         let valid2 = "m_More\ttest\nm_Key\tSome\\nNewline\\tTab\\\\escape"
-        let validResults = [valid1, valid2]
-        AssertTrue(validResults.contains(sut ?? ""))
+        let isValid = sut == valid1 || sut == valid2
+        AssertTrue(isValid)
     }
-    
+
+    func test_format_empty_meta_value() {
+        // Given
+        coreBeacon.m = ["Key": "Some\nNewline\tTab\\escape", "More": ""]
+
+        // When
+        let sut = coreBeacon.formattedKVPair(key: "m", value: coreBeacon.m!)
+
+        // Then
+        AssertEqualAndNotNil(sut, "m_Key\tSome\\nNewline\\tTab\\\\escape")
+    }
 
     func test_truncate_at_max_length() {
         // Given
-        let longString = (0...CoreBeacon.maxBytesPerField).map {"\($0)"}.joined()
+        let longString = (0...CoreBeacon.maxLengthPerField).map {"\($0)"}.joined()
         var beacon = coreBeacon!
         beacon.bt = longString
 
@@ -203,45 +225,6 @@ class CoreBeaconTests: InstanaTestCase {
         // Then
         XCTAssertNotNil(sut)
         XCTAssertTrue(sut!.hasSuffix("…"))
-    }
-
-    func test_clean_and_escape() {
-        // Given
-        let sut = "Some\nNewline\tTab\\escape"
-
-        // When
-        XCTAssertEqual(sut.cleanAndEscape(), "Some\\nNewline\\tTab\\\\escape")
-    }
-
-    func test_clean_remove_newline() {
-        // Given
-        let sut = "\n"
-
-        // When
-        XCTAssertEqual(sut.cleanAndEscape(), "")
-    }
-
-    func test_clean_remove_newline_2() {
-        // Given
-        let sut = "\nTest"
-
-        // When
-        XCTAssertEqual(sut.cleanAndEscape(), "Test")
-    }
-
-    func test_clean_remove_tab() {
-        // Given
-        let sut = "\t"
-
-        // When
-        XCTAssertEqual(sut.cleanAndEscape(), "")
-    }
-
-    func test_clean_remove_whitespace() {
-        // Given
-        let sut = " "
-
-        // When
-        XCTAssertEqual(sut.cleanAndEscape(), "")
+        XCTAssertEqual(CoreBeacon.maxLengthPerField, 16384)
     }
 }

--- a/Tests/InstanaAgentTests/Beacons/ReporterTests.swift
+++ b/Tests/InstanaAgentTests/Beacons/ReporterTests.swift
@@ -800,12 +800,12 @@ class ReporterTests: InstanaTestCase {
         AssertTrue(beacon.viewName == nil)
         AssertTrue(mockSession.propertyHandler.properties.view == nil)
         AssertTrue(mockSession.propertyHandler.properties.user == nil)
-        AssertTrue(mockSession.propertyHandler.properties.metaData == nil)
+        AssertTrue(mockSession.propertyHandler.properties.metaData.isEmpty)
         AssertTrue(reporter.preQueue.count == 1)
 
         // When
         mockSession.propertyHandler.properties.view = viewName
-        mockSession.propertyHandler.properties.metaData = ["key": "someVal"]
+        mockSession.propertyHandler.properties.appendMetaData("key", "someVal")
         mockSession.propertyHandler.properties.user = InstanaProperties.User(id: "123", email: "e@e.com", name: "John")
         wait(for: [waitForSend], timeout: prequeueTime * 2)
 

--- a/Tests/InstanaAgentTests/Configuration/InstanaPropertyHandlerTests.swift
+++ b/Tests/InstanaAgentTests/Configuration/InstanaPropertyHandlerTests.swift
@@ -4,62 +4,74 @@ import Foundation
 
 class InstanaPropertyHandlerTests: InstanaTestCase {
 
-    func test_maximumNumberOfMetaDataFields() {
-        AssertEqualAndNotZero(InstanaPropertyHandler.Const.maximumNumberOfMetaDataFields, 50)
+    func test_maxNumberOfMetaEntries() {
+        AssertEqualAndNotZero(MetaData.Max.numberOfMetaEntries, 64)
     }
 
-    func test_maximumLengthPerMetaDataField() {
-        AssertEqualAndNotZero(InstanaPropertyHandler.Const.maximumLengthPerMetaDataField, 256)
+    func test_maxLengthMetaValue() {
+        AssertEqualAndNotZero(MetaData.Max.lengthMetaValue, 256)
+    }
+
+    func test_maxLengthMetaKey() {
+        AssertEqualAndNotZero(MetaData.Max.lengthMetaKey, 98)
     }
 
     func test_validate_keys_valid() {
         // Given
-        let keys = (0..<InstanaPropertyHandler.Const.maximumNumberOfMetaDataFields).map { "key \($0)" }
-        let propertyHandler = InstanaPropertyHandler()
+        let max = MetaData.Max.numberOfMetaEntries
+        let keys = (0..<max).map { "key \($0)" }
+        let values = (0..<max).map { "value \($0)" }
+        var properties = InstanaProperties()
 
         // When
-        let sut = propertyHandler.validate(keys: keys)
+        (0..<max).forEach {index in
+            properties.appendMetaData(keys[index], values[index])
+        }
 
         // Then
-        AssertTrue(sut)
+        AssertTrue(properties.metaData.keys.count == max)
+        AssertTrue(properties.metaData.values.count == max)
     }
 
-    func test_validate_keys_invalid() {
+    func test_validate_keys_one_overflow() {
         // Given
-        let keys = (0...InstanaPropertyHandler.Const.maximumNumberOfMetaDataFields).map { "key \($0)" }
-        let propertyHandler = InstanaPropertyHandler()
+        let max = MetaData.Max.numberOfMetaEntries
+        let keys = (0...max).map { "key \($0)" }
+        let values = (0...max).map { "value \($0)" }
+        var properties = InstanaProperties()
 
         // When
-        let sut = propertyHandler.validate(keys: keys)
+        (0..<max).forEach {index in
+            properties.appendMetaData(keys[index], values[index])
+        }
 
         // Then
-        AssertTrue(sut == false)
+        AssertTrue(properties.metaData.keys.count == keys.count - 1)
+        AssertTrue(properties.metaData.keys.count == max)
     }
 
     func test_validate_value_valid() {
         // Given
-        let length = InstanaPropertyHandler.Const.maximumLengthPerMetaDataField
+        let length = MetaData.Max.lengthMetaValue
         let value = createString(length)
-        let propertyHandler = InstanaPropertyHandler()
 
         // When
-        let sut = propertyHandler.validate(value: value)
+        let sut = MetaData.validate(value: value)
 
         // Then
-        AssertTrue(sut)
+        AssertEqualAndNotNil(sut, value)
     }
 
     func test_validate_value_invalid() {
         // Given
-        let length = InstanaPropertyHandler.Const.maximumLengthPerMetaDataField
+        let length = MetaData.Max.lengthMetaValue
         let value = createString(length + 1)
-        let propertyHandler = InstanaPropertyHandler()
 
         // When
-        let sut = propertyHandler.validate(value: value)
+        let sut = MetaData.validate(value: value)
 
         // Then
-        AssertTrue(sut == false)
+        AssertEqualAndNotNil(sut, sut.cleanEscapeAndTruncate(at: length))
     }
 
     // Helper
@@ -67,3 +79,136 @@ class InstanaPropertyHandlerTests: InstanaTestCase {
         String((0...length).map { "\($0)" }.joined().suffix(length))
     }
 }
+
+class InstanaPropertiesTests: XCTestCase {
+
+    func test_appendMetaData() {
+        // Given
+        var properties = InstanaProperties()
+
+        // When
+        properties.appendMetaData("Key", "Value")
+
+        // Then
+        XCTAssertEqual(properties.metaData["Key"], "Value")
+        XCTAssertTrue(properties.metaData.count == 1)
+    }
+
+    func test_appendMetaData_exceeds_length() {
+        // Given
+        let key = (0...MetaData.Max.lengthMetaKey).map {_ in "K" }.joined()
+        let value = (0...MetaData.Max.lengthMetaValue).map {_ in "V" }.joined()
+
+        var properties = InstanaProperties()
+
+        // When
+        properties.appendMetaData(key, value)
+
+        // Then
+        let expectedKey = key.cleanEscapeAndTruncate(at: key.count - 1)
+        let expectedValue = value.cleanEscapeAndTruncate(at: value.count - 1)
+        XCTAssertEqual(properties.metaData[expectedKey], expectedValue)
+        XCTAssertEqual(properties.metaData[expectedKey]?.last, "…")
+        XCTAssertTrue(properties.metaData.count == 1)
+    }
+
+    func test_view_valid_length() {
+        // Given
+        let maxLength = InstanaProperties.viewMaxLength
+        let view = (0..<maxLength).map {_ in "V" }.joined()
+        var properties = InstanaProperties()
+
+        // When
+        properties.view = view
+
+        // Then
+        XCTAssertEqual(properties.view?.last, "V")
+        XCTAssertEqual(properties.view?.count, maxLength)
+    }
+
+    func test_view_exceeds_length() {
+        // Given
+        let maxLength = InstanaProperties.viewMaxLength
+        let view = (0...maxLength).map {_ in "V" }.joined()
+
+        // When
+        let properties = InstanaProperties(user: nil, view: view)
+
+        // Then
+        XCTAssertEqual(maxLength, 256)
+        XCTAssertEqual(properties.view?.last, "…")
+        XCTAssertEqual(properties.view?.count, maxLength)
+    }
+
+    func test_view_exceeds_length_via_setter() {
+        // Given
+        let maxLength = InstanaProperties.viewMaxLength
+        let view = (0...maxLength).map {_ in "V" }.joined()
+        var properties = InstanaProperties()
+
+        // When
+        properties.view = view
+
+        // Then
+        XCTAssertEqual(maxLength, 256)
+        XCTAssertEqual(properties.view?.last, "…")
+        XCTAssertEqual(properties.view?.count, maxLength)
+    }
+
+    func test_user_valid_length() {
+        // Given
+        let maxLength = InstanaProperties.User.userValueMaxLength
+        let value = (0..<maxLength).map {_ in "U" }.joined()
+
+        // When
+        let user = InstanaProperties.User(id: value, email: value, name: value)
+
+        // Then
+        XCTAssertEqual(user.id.last, "U")
+        XCTAssertEqual(user.email?.last, "U")
+        XCTAssertEqual(user.name?.last, "U")
+        XCTAssertEqual(user.id.count, maxLength)
+        XCTAssertEqual(user.email?.count, maxLength)
+        XCTAssertEqual(user.name?.count, maxLength)
+    }
+
+    func test_user_exceeds_length() {
+        // Given
+        let maxLength = InstanaProperties.User.userValueMaxLength
+        let value = (0...maxLength).map {_ in "U" }.joined()
+
+        // When
+        let user = InstanaProperties.User(id: value, email: value, name: value)
+
+        // Then
+        XCTAssertEqual(maxLength, 128)
+        XCTAssertEqual(user.id.last, "…")
+        XCTAssertEqual(user.email?.last, "…")
+        XCTAssertEqual(user.name?.last, "…")
+        XCTAssertEqual(user.id.count, maxLength)
+        XCTAssertEqual(user.email?.count, maxLength)
+        XCTAssertEqual(user.name?.count, maxLength)
+    }
+
+    func test_user_exceeds_length_via_setter() {
+        // Given
+        let maxLength = InstanaProperties.User.userValueMaxLength
+        let value = (0...maxLength).map {_ in "U" }.joined()
+
+        // When
+        var user = InstanaProperties.User(id: "1", email: "2", name: "3")
+        user.id = value
+        user.email = value
+        user.name = value
+
+        // Then
+        XCTAssertEqual(maxLength, 128)
+        XCTAssertEqual(user.id.last, "…")
+        XCTAssertEqual(user.email?.last, "…")
+        XCTAssertEqual(user.name?.last, "…")
+        XCTAssertEqual(user.id.count, maxLength)
+        XCTAssertEqual(user.email?.count, maxLength)
+        XCTAssertEqual(user.name?.count, maxLength)
+    }
+}
+

--- a/Tests/InstanaAgentTests/IntegrationTest/InstanaIntegrationTests.swift
+++ b/Tests/InstanaAgentTests/IntegrationTest/InstanaIntegrationTests.swift
@@ -6,33 +6,24 @@ import XCTest
 
 class InstanaIntegrationTests: InstanaTestCase {
 
-    // MARK: Setup
-    func test_setup() {
-        // Given
-        let waitFor = expectation(description: "Wait For")
-        var sentBeacon: CoreBeacon?
-        let reporter = createInstanaReporter(beaconType: .sessionStart, waitFor) { sentBeacon = $0 }
-
-        // When
-        Instana.current = Instana(session: session, configuration: session.configuration, monitors: Monitors(session, reporter: reporter))
-
-        // Then
-        wait(for: [waitFor], timeout: 5.0)
-        AssertTrue(sentBeacon != nil)
-        AssertTrue(sentBeacon?.t == BeaconType.sessionStart)
-    }
+    // Testing Singletons is hard, we test only one
 
     func test_auto_http_capture() {
         // Given
         let waitFor = expectation(description: "Wait For")
         let url = URL(string: "https://127.0.0.1/instana/some")!
         var sentBeacon: CoreBeacon?
-        let urlSession = URLSession(configuration: .default)
-        let reporter = createInstanaReporter(beaconType: .httpRequest, waitFor) { sentBeacon = $0 }
-        Instana.current = Instana(session: session, configuration: config, monitors: Monitors(session, reporter: reporter))
-        let request = URLRequest(url: url)
+        let config = InstanaConfiguration.mock(key: "KEY", reportingURL: .random, httpCaptureConfig: .automatic)
+        let session = InstanaSession.mock(configuration: config)
+        let reporter = createInstanaReporter(session: session, beaconType: .httpRequest, waitFor) { sentBeacon = $0 }
 
         // When
+        Instana.current = Instana(session: session, configuration: config, monitors: Monitors(session, reporter: reporter))
+        session.propertyHandler.properties.appendMetaData("Key", "Value")
+        session.propertyHandler.properties.view = "My View"
+        session.propertyHandler.properties.user = .init(id: "UserID", email: "email@example.com", name: "User Name")
+        let request = URLRequest(url: url)
+        let urlSession = URLSession(configuration: .default)
         urlSession.dataTask(with: request) { (data, response, error) in
         }.resume()
 
@@ -47,209 +38,33 @@ class InstanaIntegrationTests: InstanaTestCase {
         AssertTrue(sentBeacon?.ebs == nil)
         AssertTrue(sentBeacon?.dbs == nil)
         AssertTrue(sentBeacon?.trs == nil)
-    }
 
-    func test_manual_http_capture() {
-        // Given
-        let waitFor = expectation(description: "Wait For")
-        let url = URL(string: "https://127.0.0.1/instana/some")!
-        var sentBeacon: CoreBeacon?
-        let urlSession = URLSession(configuration: .default)
-        let config = InstanaConfiguration.default(key: "Key", reportingURL: .random, httpCaptureConfig: .manual)
-        let session = InstanaSession(configuration: config, propertyHandler: InstanaPropertyHandler())
-        let reporter = createInstanaReporter(beaconType: .httpRequest, waitFor) { sentBeacon = $0 }
-        Instana.current = Instana(session: session, configuration: config, monitors: Monitors(session, reporter: reporter))
-        let request = URLRequest(url: url)
-
-        // When
-        let marker = Instana.startCapture(request)
-        urlSession.dataTask(with: request) { (data, response, error) in
-            marker.set(responseSize: HTTPMarker.Size(header: 1, body: 2, bodyAfterDecoding: 3))
-            marker.finish(response: response, error: error)
-        }.resume()
-
-        // Then
-        wait(for: [waitFor], timeout: 5.0)
-        AssertTrue(sentBeacon != nil)
-        AssertTrue(sentBeacon?.t == BeaconType.httpRequest)
-        AssertEqualAndNotNil(sentBeacon?.hm, "GET")
-        AssertEqualAndNotNil(sentBeacon?.hp, url.path)
-        AssertEqualAndNotNil(sentBeacon?.hs, "-1")
-        AssertEqualAndNotNil(sentBeacon?.hu, url.absoluteString)
-        AssertEqualAndNotNil(sentBeacon?.ebs, "2")
-        AssertEqualAndNotNil(sentBeacon?.dbs, "3")
-        AssertEqualAndNotNil(sentBeacon?.trs, "3")
-    }
-
-    // MARK: Meta
-    func test_set_meta_delayed() {
-        // Given
-        let value = "some@example.com"
-        let key = "User"
-        let waitFor = expectation(description: "Wait For")
-        var sentBeacon: CoreBeacon?
-        createInstanaReporter(beaconType: .viewChange, waitFor) { sentBeacon = $0 }
-
-        // When
-        Instana.setMeta(value: value, key: key)
-        Instana.setView(name: "Something")
-
-        // Then
-        wait(for: [waitFor], timeout: 5.0)
-        AssertTrue(sentBeacon != nil)
-        AssertEqualAndNotNil(sentBeacon?.m?[key], value)
-    }
-
-    // MARK: User
-    func test_set_user_delayed() {
-        // Given
-        let email = "some@example.com"
-        let name = "User name"
-        let userID = UUID().uuidString
-        let waitFor = expectation(description: "Wait For")
-        var sentBeacon: CoreBeacon?
-        createInstanaReporter(beaconType: .viewChange, waitFor) { sentBeacon = $0 }
-
-        // When
-        Instana.setUser(id: userID, email: email, name: name)
-        Instana.setView(name: "Something")
-
-        // Then
-        wait(for: [waitFor], timeout: 5.0)
-        AssertTrue(sentBeacon != nil)
-        AssertEqualAndNotNil(sentBeacon?.ui, userID)
-        AssertEqualAndNotNil(sentBeacon?.ue, email)
-        AssertEqualAndNotNil(sentBeacon?.un, name)
-    }
-
-    // MARK: ViewName
-    func test_Instana_set_viewName() {
-        // Given
-        let viewName = "Some View"
-        let waitFor = expectation(description: "Wait For")
-        var sentBeacon: CoreBeacon?
-        createInstanaReporter(beaconType: .viewChange, waitFor) { sentBeacon = $0 }
-
-        // When
-        Instana.setView(name: viewName)
-
-        // Then
-        wait(for: [waitFor], timeout: 5.0)
-        AssertTrue(sentBeacon != nil)
-        AssertEqualAndNotNil(sentBeacon?.v, viewName)
-        AssertTrue(sentBeacon?.v != nil)
-    }
-
-    // MARK: Custom Event
-    func test_Instana_report_custom_event() {
-        // Given
-        let waitFor = expectation(description: "Wait For")
-        let timestamp: Instana.Types.Milliseconds = 1234
-        let name = "Some name"
-        let duration: Instana.Types.Milliseconds = 12
-        let backendTracingID = "BackendID"
-        let error = InstanaError.invalidResponse
-        let mKey = "Key"
-        let mValue = "Value"
-        let viewName = "View"
-        var sentBeacon: CoreBeacon?
-        createInstanaReporter(beaconType: .custom, waitFor) { sentBeacon = $0 }
-        session.propertyHandler.properties.metaData = ["Key": "MyValue"]
-        session.propertyHandler.properties.view = "My View"
-
-        // When
-        Instana.reportEvent(name: name, timestamp: timestamp, duration: duration, backendTracingID: backendTracingID, error: error, meta: [mKey: mValue], viewName: viewName)
-
-        // Then
-        wait(for: [waitFor], timeout: 5.0)
-        AssertEqualAndNotNil(sentBeacon?.v, viewName) // Overrides the default set in session.propertyHandler.properties
-        AssertEqualAndNotNil(sentBeacon?.bt, backendTracingID)
-        AssertEqualAndNotNil(sentBeacon?.ti, "\(timestamp)")
-        AssertEqualAndNotNil(sentBeacon?.d, "\(duration)")
-        AssertEqualAndNotNil(sentBeacon?.cen, name)
-        AssertEqualAndNotNil(sentBeacon?.ec, "\(1)")
-        AssertEqualAndNotNil(sentBeacon?.et, "InstanaError")
-        AssertEqualAndNotNil(sentBeacon?.em, "Error Domain=com.instana.ios.agent.error Code=2 \"Some\" UserInfo={NSLocalizedDescription=Some}")
-        AssertEqualAndNotNil(sentBeacon?.m?[mKey], mValue) // Overrides the default set in session.propertyHandler.properties
-    }
-
-    func test_Instana_report_custom_event_current_viewName() {
-        // Given
-        let name = "Some name"
-        let waitFor = expectation(description: "Wait For")
-        var sentBeacon: CoreBeacon?
-        createInstanaReporter(beaconType: .custom, waitFor) { sentBeacon = $0 }
-
-        // When
-        Instana.setView(name: "View")
-        Instana.reportEvent(name: name)
-
-        // Then
-        wait(for: [waitFor], timeout: 5.0)
-        AssertTrue(sentBeacon != nil)
-        AssertEqualAndNotNil(sentBeacon?.cen, name)
-        AssertTrue(Instana.viewName != nil)
-        AssertEqualAndNotNil(sentBeacon?.v, Instana.viewName)
-    }
-
-    func test_Instana_report_custom_event_no_viewName() {
-        // Given
-        let name = "Some name"
-        let waitFor = expectation(description: "Wait For")
-        var sentBeacon: CoreBeacon?
-        createInstanaReporter(beaconType: .custom, waitFor) { sentBeacon = $0 }
-
-        // When
-        Instana.reportEvent(name: name, viewName: nil)
-
-        // Then
-        wait(for: [waitFor], timeout: 5.0)
-        AssertTrue(sentBeacon != nil)
-        AssertEqualAndNotNil(sentBeacon?.cen, name)
-        AssertTrue(sentBeacon?.v == nil)
-    }
-
-    func test_default_values() {
-        // Given
-        let waitFor = expectation(description: "Wait For")
-        var serverBeacon: CoreBeacon!
-        createInstanaReporter(beaconType: .custom, waitFor) { serverBeacon = $0 }
-        session.propertyHandler.properties.metaData = ["Key": "MyValue"]
-        session.propertyHandler.properties.user = .init(id: "UserID", email: "email@example.com", name: "User Name")
-        session.propertyHandler.properties.view = "My View"
-
-        // When
-        Instana.reportEvent(name: "Event name", viewName: "my view")
-
-        // Then
-        wait(for: [waitFor], timeout: 5.0)
-        AssertEqualAndNotNil(serverBeacon.ab, InstanaSystemUtils.applicationBuildNumber)
-        AssertEqualAndNotNil(serverBeacon.av, InstanaSystemUtils.applicationVersion)
-        AssertEqualAndNotNil(serverBeacon.agv, InstanaSystemUtils.agentVersion)
-        AssertEqualAndNotNil(serverBeacon.bi, "com.apple.dt.xctest.tool")
-        AssertEqualAndNotNil(serverBeacon.ct, "Wifi")
-        AssertEqualAndNotNil(serverBeacon.t, BeaconType.custom)
-        AssertEqualAndNotNil(serverBeacon.cn, "None")
-        AssertEqualAndNotNil(serverBeacon.dma, "Apple")
-        AssertEqualAndNotNil(serverBeacon.cen, "Event name")
-        AssertEqualAndNotNil(serverBeacon.v, "my view") // Overrides the original
-        AssertEqualAndNotNil(serverBeacon.vh, "\(Int(UIScreen.main.nativeBounds.size.height))")
-        AssertEqualAndNotNil(serverBeacon.vw, "\(Int(UIScreen.main.nativeBounds.size.width))")
-        AssertEqualAndNotNil(serverBeacon.osv, InstanaSystemUtils.systemVersion)
-        AssertEqualAndNotNil(serverBeacon.osn, "iOS")
-        AssertEqualAndNotNil(serverBeacon.p, "iOS")
-        AssertEqualAndNotNil(serverBeacon.m, ["Key": "MyValue"])
-        AssertEqualAndNotNil(serverBeacon.ui, "UserID")
-        AssertEqualAndNotNil(serverBeacon.ue, "email@example.com")
-        AssertEqualAndNotNil(serverBeacon.un, "User Name")
-        AssertEqualAndNotNil(serverBeacon.ul, "en")
+        AssertEqualAndNotNil(sentBeacon?.ab, InstanaSystemUtils.applicationBuildNumber)
+        AssertEqualAndNotNil(sentBeacon?.av, InstanaSystemUtils.applicationVersion)
+        AssertEqualAndNotNil(sentBeacon?.agv, InstanaSystemUtils.agentVersion)
+        AssertEqualAndNotNil(sentBeacon?.bi, "com.apple.dt.xctest.tool")
+        AssertEqualAndNotNil(sentBeacon?.ct, "Wifi")
+        AssertEqualAndNotNil(sentBeacon?.t, BeaconType.httpRequest)
+        AssertEqualAndNotNil(sentBeacon?.cn, "None")
+        AssertEqualAndNotNil(sentBeacon?.dma, "Apple")
+        AssertEqualAndNotNil(sentBeacon?.cen, nil)
+        AssertEqualAndNotNil(sentBeacon?.v, "My View") // Overrides the original
+        AssertEqualAndNotNil(sentBeacon?.vh, "\(Int(UIScreen.main.nativeBounds.size.height))")
+        AssertEqualAndNotNil(sentBeacon?.vw, "\(Int(UIScreen.main.nativeBounds.size.width))")
+        AssertEqualAndNotNil(sentBeacon?.osv, InstanaSystemUtils.systemVersion)
+        AssertEqualAndNotNil(sentBeacon?.osn, "iOS")
+        AssertEqualAndNotNil(sentBeacon?.p, "iOS")
+        AssertEqualAndNotNil(sentBeacon?.m, ["Key": "Value"])
+        AssertEqualAndNotNil(sentBeacon?.ui, "UserID")
+        AssertEqualAndNotNil(sentBeacon?.ue, "email@example.com")
+        AssertEqualAndNotNil(sentBeacon?.un, "User Name")
+        AssertEqualAndNotNil(sentBeacon?.ul, "en")
     }
 
     // MARK: Helper
     @discardableResult
-    func createInstanaReporter(session: InstanaSession? = nil, beaconType: BeaconType, _ waitFor: XCTestExpectation, _ reporterCompletion: @escaping (CoreBeacon) -> Void) -> Reporter {
-        let thesession = session ?? self.session!
-        let reporter = Reporter(thesession, networkUtility: .wifi) {request, completion   in
+    func createInstanaReporter(session: InstanaSession, beaconType: BeaconType, _ waitFor: XCTestExpectation, _ reporterCompletion: @escaping (CoreBeacon) -> Void) -> Reporter {
+        let reporter = Reporter(session, networkUtility: .wifi) {request, completion   in
             let serverReceivedHTTP = String(data: request.httpBody ?? Data(), encoding: .utf8)
             let sentBeacon = try? CoreBeacon.create(from: serverReceivedHTTP ?? "")
             if let sentBeacon = sentBeacon, sentBeacon.t == beaconType {
@@ -257,7 +72,6 @@ class InstanaIntegrationTests: InstanaTestCase {
                 reporterCompletion(sentBeacon)
             }
         }
-        Instana.current = Instana(session: thesession, configuration: thesession.configuration, monitors: Monitors(thesession, reporter: reporter))
         reporter.completionHandler.append {_ in
             DispatchQueue.main.async {
                 waitFor.fulfill()

--- a/Tests/InstanaAgentTests/Mocks/MockInstanaConfiguration.swift
+++ b/Tests/InstanaAgentTests/Mocks/MockInstanaConfiguration.swift
@@ -9,7 +9,8 @@ extension InstanaConfiguration {
 
     static func mock(key: String = "KEY",
                      reportingURL: URL = .random,
-                     httpCaptureConfig: HTTPCaptureConfig = .automatic) -> InstanaConfiguration {
+                     httpCaptureConfig: HTTPCaptureConfig = .automatic,
+                     gzipReport: Bool = false) -> InstanaConfiguration {
         InstanaConfiguration(reportingURL: reportingURL,
                              key: key,
                              httpCaptureConfig: httpCaptureConfig,
@@ -20,7 +21,7 @@ extension InstanaConfiguration {
                                             .alertApplicationNotResponding(threshold: 2.0)],
                              transmissionDelay: 0.0,
                              transmissionLowBatteryDelay: 0.0,
-                             gzipReport: true,
+                             gzipReport: gzipReport,
                              maxBeaconsPerRequest: 100,
                              preQueueUsageTime: 0.0)
     }

--- a/Tests/InstanaAgentTests/Mocks/MockInstanaEnvironment.swift
+++ b/Tests/InstanaAgentTests/Mocks/MockInstanaEnvironment.swift
@@ -10,13 +10,18 @@ extension InstanaSession {
 
     static func mock(configuration: InstanaConfiguration = .mock,
                      sessionID: UUID? = nil,
-                     metaData: [String: String]? = nil,
+                     metaData: MetaData = [:],
                      user: InstanaProperties.User? = nil,
                      currentView: String? = nil) -> InstanaSession {
         let sessionID = sessionID ?? UUID()
         let metaData = metaData
         let propertyHandler = InstanaPropertyHandler()
-        propertyHandler.properties = InstanaProperties(user: user, metaData: metaData, view: currentView)
+        var properties = InstanaProperties(user: user, view: currentView)
+        metaData.forEach { (key, value) in
+            properties.appendMetaData(key, value)
+        }
+        propertyHandler.properties = properties
+
         return InstanaSession(configuration: configuration, propertyHandler: propertyHandler, sessionID: sessionID)
     }
 }

--- a/Tests/InstanaAgentTests/Test helpers/XCTestCaseExtensions.swift
+++ b/Tests/InstanaAgentTests/Test helpers/XCTestCaseExtensions.swift
@@ -26,7 +26,6 @@ extension InstanaTestCase {
     }
 }
 
-// TODO: Rename all to Expect... instead of Assert...
 func AssertEqualAndNotNil<T: Equatable>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(try expression1(), try expression2(), message(), file: file, line: line)
     XCTAssertNotNil(try expression1(), message(), file: file, line: line)

--- a/Tests/InstanaAgentTests/Utils_Tests/Extensions/StringExtensionTests.swift
+++ b/Tests/InstanaAgentTests/Utils_Tests/Extensions/StringExtensionTests.swift
@@ -9,10 +9,10 @@ class StringExtensionTests: InstanaTestCase {
         let longString = (0...50).map {"\($0)"}.joined()
 
         // When
-        let sut = longString.truncated(at: 10, trailing: ".....")
+        let sut = longString.maxLength(10, trailing: ".....")
 
         // Then
-        AssertTrue(sut == "0123456789.....")
+        AssertEqualAndNotNil(sut, "01234.....")
     }
 
     func test_truncate_no_trailing_Dots() {
@@ -20,9 +20,48 @@ class StringExtensionTests: InstanaTestCase {
         let longString = (0...50).map {"\($0)"}.joined()
 
         // When
-        let sut = longString.truncated(at: 10, trailing: "")
+        let sut = longString.maxLength(10, trailing: "")
 
         // Then
         AssertTrue(sut == "0123456789")
+    }
+
+    func test_clean_and_escape() {
+        XCTAssertEqual("Some\nNewline\tTab\\escape".cleanEscape(), "Some\\nNewline\\tTab\\\\escape")
+        XCTAssertEqual("Some\nNewline\tTab\\escape".coreBeaconClean(), "Some\\nNewline\\tTab\\\\escape")
+    }
+
+    func test_clean_remove_newline() {
+        XCTAssertEqual("\n".cleanEscape(), "")
+        XCTAssertEqual("\n".coreBeaconClean(), "")
+    }
+
+    func test_clean_remove_newline_2() {
+        XCTAssertEqual("\nTest".cleanEscape(), "Test")
+        XCTAssertEqual("\nTest".coreBeaconClean(), "Test")
+    }
+
+    func test_clean_remove_tab() {
+        XCTAssertEqual("\t".cleanEscape(), "")
+        XCTAssertEqual("\t".coreBeaconClean(), "")
+    }
+
+    func test_clean_remove_whitespace() {
+        XCTAssertEqual(" ".cleanEscape(), "")
+        XCTAssertEqual(" ".coreBeaconClean(), "")
+    }
+
+    func test_truncate_default() {
+        XCTAssertEqual("ABCD".maxLength(3), "AB…")
+    }
+
+    func test_truncate_custom_trailing() {
+        XCTAssertEqual("ABCD".maxLength(3, trailing: ">>"), "A>>")
+    }
+
+    func test_truncate_corebeacon() {
+        let given = (0...CoreBeacon.maxLengthPerField).map {_ in "A"}.joined()
+        let expected = String(given.prefix(CoreBeacon.maxLengthPerField-1)) + "…"
+        XCTAssertEqual(given.coreBeaconClean(), expected)
     }
 }

--- a/Tests/InstanaAgentTests/Utils_Tests/Networking/InstanaNetworkingTests.swift
+++ b/Tests/InstanaAgentTests/Utils_Tests/Networking/InstanaNetworkingTests.swift
@@ -59,7 +59,7 @@ class InstanaNetworkingTests: InstanaTestCase {
 
     func test_networking_parsesResponseSatusCode_invalid_response() {
         var invocations = 0
-        let random500: Int = (600...1999).randomElement() ?? 600
+        let random500: Int = (600...699).randomElement() ?? 600
         let networking = InstanaNetworking(send: { TestSessionDataTask(response: self.validResponse(statusCode: random500), callback: $1) })
         networking.send(request: URLRequest(url: testURL)) {
             if case .failure(InstanaError.invalidResponse) = $0 {


### PR DESCRIPTION
- MetaData can have maximum 64 key value pairs
- Allow MetaData keys with max. length of 98 length and values with max. of 256 length for each entry
- User properties have max length of 128 length
- ViewName has max length of 256 length
- HTTP URL and path have max length of 4096
- Update tests