### PR TITLE
Adds new flag `collectionEnabled`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.0
+- Added new flag `collectionEnabled` to set up Instana without data collection. Instrumentation can be enabled later using this property. This allows apps to start Instana with a delay if users are asked for consent beforehand. 
+
 ## 1.1.18
 - Fix setting responseSize
 - Make originalTask weak

--- a/Dev/InstanaAgentExample/AppDelegate.swift
+++ b/Dev/InstanaAgentExample/AppDelegate.swift
@@ -12,7 +12,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         Instana.setup(key: InstanaKey, reportingURL: InstanaURL)
-
         return true
     }
 

--- a/Dev/iOSAgentUITests/iOSAgentUITests.swift
+++ b/Dev/iOSAgentUITests/iOSAgentUITests.swift
@@ -45,32 +45,6 @@ class iOSAgentUITests: XCTestCase {
         XCTAssertTrue(types.contains("httpRequest"))
     }
 
-    func test_flush_after_error() {
-        // Given
-        launchServer(stubbedHTTPResponse: 500)
-        launchApp()
-
-        // When (Server not found)
-        load("https://api.mygigs.tapwork.de")
-
-        // Then (Beacon should not be transmitted)
-        webserver.verifyBeaconNotReceived(key: "hu", value: "https://api.mygigs.tapwork.de")
-
-        // When
-        webserver.stub(httpStatusResponse: 200)
-        delay(2.0)
-        app.tabBars.buttons["Top Rated"].tap()
-
-        // Then
-        delay(4.0)
-        verify(app.images.firstMatch)
-        delay(5.0)
-        // Check if the first beacon has been transmitted now
-        webserver.verifyBeaconReceived(key: "hu", value: "https://api.mygigs.tapwork.de")
-        // And verify the new beacon
-        webserver.verifyBeaconReceived(key: "hu", value: "https://i.picsum.photos/")
-    }
-
     func test_start_new_session_after_launch() {
         // Given
         launchServer()
@@ -115,7 +89,7 @@ class iOSAgentUITests: XCTestCase {
         webserver = Webserver(port: port)
         webserver.start()
         webserver.stub(httpStatusResponse: stubbedHTTPResponse)
-        delay(3.0)
+        delay(5.0)
     }
 
     func launchApp(ignoreQueuePersistence: Bool = true) {

--- a/InstanaAgent.podspec
+++ b/InstanaAgent.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "InstanaAgent"
-  s.version      = "1.1.18"
+  s.version      = "1.2.0"
   s.summary      = "Instana iOS agent."
 
   # This description is used to generate tags and improve search results.

--- a/Sources/InstanaAgent/Beacons/Reporter.swift
+++ b/Sources/InstanaAgent/Beacons/Reporter.swift
@@ -57,6 +57,11 @@ public class Reporter {
     func submit(_ beacon: Beacon, _ completion: (() -> Void)? = nil) {
         dispatchQueue.async { [weak self] in
             guard let self = self else { return }
+            guard self.session.collectionEnabled else {
+                self.session.logger.add("Instana instrumentation is disabled. Beacon will be discarded", level: .warning)
+                completion?()
+                return
+            }
             guard self.rateLimiter.canSubmit() else {
                 self.session.logger.add("Rate Limit reached - Beacon will be discarded", level: .warning)
                 completion?()

--- a/Sources/InstanaAgent/Configuration/InstanaSession.swift
+++ b/Sources/InstanaAgent/Configuration/InstanaSession.swift
@@ -20,9 +20,12 @@ class InstanaSession {
     /// A debugging console logger using levels
     let logger = InstanaLogger()
 
-    init(configuration: InstanaConfiguration, propertyHandler: InstanaPropertyHandler, sessionID: UUID = UUID()) {
+    var collectionEnabled: Bool
+
+    init(configuration: InstanaConfiguration, propertyHandler: InstanaPropertyHandler, sessionID: UUID = UUID(), collectionEnabled: Bool) {
         self.configuration = configuration
         self.propertyHandler = propertyHandler
+        self.collectionEnabled = collectionEnabled
         id = sessionID
     }
 }

--- a/Sources/InstanaAgent/Configuration/VersionConfig.swift
+++ b/Sources/InstanaAgent/Configuration/VersionConfig.swift
@@ -1,3 +1,3 @@
 struct VersionConfig {
-    static let agentVersion = "1.1.18"
+    static let agentVersion = "1.2.0"
 }

--- a/Sources/InstanaAgent/Monitors/Monitors.swift
+++ b/Sources/InstanaAgent/Monitors/Monitors.swift
@@ -11,6 +11,7 @@ class Monitors {
     var http: HTTPMonitor?
     let reporter: Reporter
     private let session: InstanaSession
+    private var startBeaconTriggered = false
 
     init(_ session: InstanaSession, reporter: Reporter? = nil) {
         self.session = session
@@ -27,6 +28,15 @@ class Monitors {
             case let .alertApplicationNotResponding(threshold):
                 applicationNotResponding = ApplicationNotRespondingMonitor(threshold: threshold, reporter: reporter)
             }
+        }
+
+        submitStartBeaconIfNeeded()
+    }
+
+    func submitStartBeaconIfNeeded() {
+        if session.configuration.isValid, session.collectionEnabled, !startBeaconTriggered {
+            reporter.submit(SessionProfileBeacon(state: .start))
+            startBeaconTriggered = true
         }
     }
 }

--- a/Tests/InstanaAgentTests/Beacons/ReporterTests.swift
+++ b/Tests/InstanaAgentTests/Beacons/ReporterTests.swift
@@ -866,9 +866,9 @@ class ReporterTests: InstanaTestCase {
         AssertTrue(reporter.preQueue.count == 1)
 
         // When
-        wait(prequeueTime + 0.1)
+        wait(prequeueTime + 0.5)
         reporter.submit(beaconAfterQueue)
-        wait(for: [waitForSend], timeout: prequeueTime * 8)
+        wait(for: [waitForSend], timeout: prequeueTime + 0.5)
 
         // Then
         AssertEqualAndNotNil(sendCount, 2) // The prequeue has been flushed only

--- a/Tests/InstanaAgentTests/Configuration/InstanaSessionTests.swift
+++ b/Tests/InstanaAgentTests/Configuration/InstanaSessionTests.swift
@@ -13,11 +13,12 @@ class InstanaSessionTests: InstanaTestCase {
         let propertyHandler = InstanaPropertyHandler()
 
         // When
-        let sut = InstanaSession(configuration: config, propertyHandler: propertyHandler)
+        let sut = InstanaSession(configuration: config, propertyHandler: propertyHandler, collectionEnabled: true)
 
         // Then
         AssertTrue(!sut.id.uuidString.isEmpty)
         AssertEqualAndNotNil(sut.propertyHandler, propertyHandler)
         AssertEqualAndNotNil(sut.configuration, config)
+        AssertTrue(sut.collectionEnabled)
     }
 }

--- a/Tests/InstanaAgentTests/Configuration/InstanaSystemUtilsTests.swift
+++ b/Tests/InstanaAgentTests/Configuration/InstanaSystemUtilsTests.swift
@@ -5,7 +5,7 @@ class InstanaSystemUtilsTests: InstanaTestCase {
 
     func test_AgentVersion() {
         // Then
-        AssertTrue(InstanaSystemUtils.agentVersion == "1.1.18")
+        AssertTrue(InstanaSystemUtils.agentVersion == "1.2.0")
     }
 
     func test_systemVersion() {

--- a/Tests/InstanaAgentTests/IntegrationTest/InstanaURLProtocolIntegrationTests.swift
+++ b/Tests/InstanaAgentTests/IntegrationTest/InstanaURLProtocolIntegrationTests.swift
@@ -30,7 +30,7 @@ class InstanaURLProtocolIntegrationTests: InstanaTestCase {
             }
         }
         let monitors = Monitors(session, reporter: mockReporter)
-        Instana.current = Instana(session: session, configuration: session.configuration, monitors: monitors)
+        Instana.current = Instana(session: session, monitors: monitors)
 
         // When
         URLSession.shared.dataTask(with: givenURL) {_, _, _ in}.resume()
@@ -51,7 +51,7 @@ class InstanaURLProtocolIntegrationTests: InstanaTestCase {
             }
         }
         let monitors = Monitors(session, reporter: mockReporter)
-        Instana.current = Instana(session: session, configuration: session.configuration, monitors: monitors)
+        Instana.current = Instana(session: session, monitors: monitors)
         let config = URLSessionConfiguration.default
         config.protocolClasses?.insert(SecondURLProtocol.self, at: 0)
         urlSession = URLSession(configuration: config)
@@ -76,7 +76,7 @@ class InstanaURLProtocolIntegrationTests: InstanaTestCase {
             }
         }
         let monitors = Monitors(session, reporter: mockReporter)
-        Instana.current = Instana(session: session, configuration: session.configuration, monitors: monitors)
+        Instana.current = Instana(session: session, monitors: monitors)
         urlSession = URLSession(configuration: URLSessionConfiguration.default)
 
         // When

--- a/Tests/InstanaAgentTests/IntegrationTest/URLSessionTaskIntegrationTests.swift
+++ b/Tests/InstanaAgentTests/IntegrationTest/URLSessionTaskIntegrationTests.swift
@@ -28,7 +28,7 @@ class URLSessionTaskIntegrationTests: InstanaTestCase {
             self.sentBeacon = try? CoreBeacon.create(from: value ?? "")
         })
         reporter.queue.items.removeAll()
-        Instana.current = Instana(session: session, configuration: session.configuration, monitors: Monitors(session, reporter: reporter))
+        Instana.current = Instana(session: session, monitors: Monitors(session, reporter: reporter))
 
         let waitForLaunch = expectation(description: "webserver")
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {

--- a/Tests/InstanaAgentTests/Mocks/MockInstanaSession.swift
+++ b/Tests/InstanaAgentTests/Mocks/MockInstanaSession.swift
@@ -17,7 +17,8 @@ extension InstanaSession {
                      sessionID: UUID? = nil,
                      metaData: MetaData = [:],
                      user: InstanaProperties.User? = nil,
-                     currentView: String? = nil) -> InstanaSession {
+                     currentView: String? = nil,
+                     collectionEnabled: Bool = true) -> InstanaSession {
         let sessionID = sessionID ?? UUID()
         let metaData = metaData
         let propertyHandler = InstanaPropertyHandler()
@@ -27,6 +28,6 @@ extension InstanaSession {
         }
         propertyHandler.properties = properties
 
-        return InstanaSession(configuration: configuration, propertyHandler: propertyHandler, sessionID: sessionID)
+        return InstanaSession(configuration: configuration, propertyHandler: propertyHandler, sessionID: sessionID, collectionEnabled: collectionEnabled)
     }
 }

--- a/Tests/InstanaAgentTests/Test helpers/InstanaTestCase.swift
+++ b/Tests/InstanaAgentTests/Test helpers/InstanaTestCase.swift
@@ -13,7 +13,7 @@ class InstanaTestCase: XCTestCase {
         var config = InstanaConfiguration.mock(key: "KEY", reportingURL: .random, httpCaptureConfig: .automatic)
         config.gzipReport = false
         let session = InstanaSession.mock(configuration: config)
-        let instana = Instana(session: session, configuration: config)
+        let instana = Instana(session: session)
         Instana.current = instana
         return instana
     }()


### PR DESCRIPTION
to set up Instana without data collection. Instrumentation can be enabled later using this property. This allows apps to start Instana with a delay if users are asked for consent beforehand.